### PR TITLE
Only process tasks that are at the root level

### DIFF
--- a/src/main/kotlin/service/TaskService.kt
+++ b/src/main/kotlin/service/TaskService.kt
@@ -1,6 +1,5 @@
 package service
 
-import NeuralLinkPlugin
 import kotlin.js.Date
 import moment.moment
 
@@ -21,6 +20,7 @@ class TaskService() {
     private val specificValues = listOf("month", "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec")
     private val spanRegex = spanValues.plus(specificValues).joinToString("|")
     private val repeatItemRegex = Regex("""($spanRegex)([!]?): ([0-9]{1,2})""")
+    @Suppress("RegExpRedundantEscape")
     private val completedTaskRegex = Regex("""- \[[xX]\] """)
 
     /**


### PR DESCRIPTION
Filters the ListItemCache items to only process root tasks. A better method will come once a Task model is in place but this will reduce the amount of tasks that need to be checked. I'm not filtering on ListItemCache.task at the moment because that is checked with the first `if` statement.

Includes a little cleanup with TaskService.